### PR TITLE
Fixed usage with other plugins which used special plugins (with zero-byte ahead)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,12 +24,11 @@ export default function RollupPluginPreprocess ({
 
     /**
      * @param {string} fileName
-     * @returns {string}
+     * @returns {(string|undefined)}
      */
     load (fileName) {
-      let data = fs.readFileSync(fileName, 'utf8');
-
       if (filter(fileName)) {
+        const data = fs.readFileSync(fileName, 'utf8');
         if (!options.type) {
           const ext = path.extname(fileName);
 
@@ -38,10 +37,8 @@ export default function RollupPluginPreprocess ({
           }
         }
 
-        data = pp.preprocess(data, context, options);
+        return pp.preprocess(data, context, options);
       }
-
-      return data;
     }
   };
 };


### PR DESCRIPTION
I using `rollup-plugin-typescript` and it adds special module `\0typescript-helpers` (with zero-byte ahead) (https://github.com/rollup/rollup-plugin-typescript/blob/master/src/index.js#L24). But if I add `rollup-plugin-preprocess` at the top of the list of plugins the plugin will be trying to load this module and will get an error `Path must be a string without null bytes`.
I guess the loader should read file if it is not filtered only.
This PR fixes it.